### PR TITLE
Apptree

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "Lib/apptree"]
+	path = Lib/apptree
+	url = https://github.com/cmlaw1993/apptree.git

--- a/Simple_Waveform_Generator.uvoptx
+++ b/Simple_Waveform_Generator.uvoptx
@@ -255,8 +255,8 @@
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
       <bDave2>0</bDave2>
-      <PathWithFileName>.\dma.c</PathWithFileName>
-      <FilenameWithoutPath>dma.c</FilenameWithoutPath>
+      <PathWithFileName>.\Lib\apptree\Sources\apptree.c</PathWithFileName>
+      <FilenameWithoutPath>apptree.c</FilenameWithoutPath>
       <RteFlg>0</RteFlg>
       <bShared>0</bShared>
     </File>
@@ -311,8 +311,20 @@
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
       <bDave2>0</bDave2>
-      <PathWithFileName>.\dma.h</PathWithFileName>
-      <FilenameWithoutPath>dma.h</FilenameWithoutPath>
+      <PathWithFileName>.\Lib\apptree\Includes\apptree.h</PathWithFileName>
+      <FilenameWithoutPath>apptree.h</FilenameWithoutPath>
+      <RteFlg>0</RteFlg>
+      <bShared>0</bShared>
+    </File>
+    <File>
+      <GroupNumber>2</GroupNumber>
+      <FileNumber>8</FileNumber>
+      <FileType>5</FileType>
+      <tvExp>0</tvExp>
+      <tvExpOptDlg>0</tvExpOptDlg>
+      <bDave2>0</bDave2>
+      <PathWithFileName>.\Lib\apptree\Includes\list.h</PathWithFileName>
+      <FilenameWithoutPath>list.h</FilenameWithoutPath>
       <RteFlg>0</RteFlg>
       <bShared>0</bShared>
     </File>

--- a/Simple_Waveform_Generator.uvprojx
+++ b/Simple_Waveform_Generator.uvprojx
@@ -322,7 +322,7 @@
             <wLevel>2</wLevel>
             <uThumb>0</uThumb>
             <uSurpInc>0</uSurpInc>
-            <uC99>0</uC99>
+            <uC99>1</uC99>
             <useXO>0</useXO>
             <v6Lang>1</v6Lang>
             <v6LangP>1</v6LangP>
@@ -332,7 +332,7 @@
               <MiscControls></MiscControls>
               <Define></Define>
               <Undefine></Undefine>
-              <IncludePath></IncludePath>
+              <IncludePath>.\Lib\apptree\Includes</IncludePath>
             </VariousControls>
           </Cads>
           <Aads>
@@ -391,9 +391,9 @@
               <FilePath>.\timer.c</FilePath>
             </File>
             <File>
-              <FileName>dma.c</FileName>
+              <FileName>apptree.c</FileName>
               <FileType>1</FileType>
-              <FilePath>.\dma.c</FilePath>
+              <FilePath>.\Lib\apptree\Sources\apptree.c</FilePath>
             </File>
             <File>
               <FileName>WaveGen.c</FileName>
@@ -416,9 +416,14 @@
               <FilePath>.\timer.h</FilePath>
             </File>
             <File>
-              <FileName>dma.h</FileName>
+              <FileName>apptree.h</FileName>
               <FileType>5</FileType>
-              <FilePath>.\dma.h</FilePath>
+              <FilePath>.\Lib\apptree\Includes\apptree.h</FilePath>
+            </File>
+            <File>
+              <FileName>list.h</FileName>
+              <FileType>5</FileType>
+              <FilePath>.\Lib\apptree\Includes\list.h</FilePath>
             </File>
             <File>
               <FileName>WaveGen.h</FileName>


### PR DESCRIPTION
This adds the apptree submodule into the project. The apptree is added into ./Lib/apptree/.
The include directory is updated to point to the apptree include directory at ./Lib/apptree/Includes.
C99 standard is also enabled for the compiler to support inline functions found in list.h of the apptree.
